### PR TITLE
Fixes #9: updates shiny Dockerfile in README.md and MIGRATING.md

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -17,7 +17,7 @@ In your R application source's root directory:
   ```
   FROM virtualstaticvoid/heroku-docker-r:shiny
   ENV PORT=8080
-  CMD "/usr/bin/R --no-save -f /app/run.R"
+  CMD ["/usr/bin/R", "--no-save", "--gui-none", "-f /app/run.R"]
   ```
 
 * Create a `heroku.yml` file and insert the following content.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In your Shiny application source's root directory:
   ```
   FROM virtualstaticvoid/heroku-docker-r:shiny
   ENV PORT=8080
-  CMD "/usr/bin/R --no-save -f /app/run.R"
+  CMD ["/usr/bin/R", "--no-save", "--gui-none", "-f /app/run.R"]
   ```
 
 * Create a `heroku.yml` file and insert the following content.


### PR DESCRIPTION
Fixes #9 

Updated the shiny Dockerfile in the markdown files to match the [Dockerfile in the shiny example](https://github.com/virtualstaticvoid/heroku-docker-r-examples/blob/master/shiny/Dockerfile).